### PR TITLE
Removed build warning for -sizeWithFont usage on iOS 7 builds

### DIFF
--- a/MLPAccessoryBadge/MLPAccessoryBadge.m
+++ b/MLPAccessoryBadge/MLPAccessoryBadge.m
@@ -242,7 +242,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 - (void)resizeFrame
 {
-    CGSize size = [self.textLabel.text sizeWithFont:self.textLabel.font];
+    CGSize size = [self.textLabel.text sizeWithAttributes:@{NSFontAttributeName:self.textLabel.font}];
     size.width += self.textSizePadding.width;
     size.height += self.textSizePadding.height;
     


### PR DESCRIPTION
I updated the usage of -sizeWithFont to -sizeWithAttributes to remove the build warning on iOS 7 targets. I made sure this was backwards compatible with iOS 6.x builds as well.
