### PR TITLE
* make it backwards compatible with iOS 6 after Pullrequest  (EddyBorja/MLPAccessoryBadge#2) and one fix

### DIFF
--- a/MLPAccessoryBadge/MLPAccessoryBadge.m
+++ b/MLPAccessoryBadge/MLPAccessoryBadge.m
@@ -244,7 +244,16 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 {
     if (self.textLabel == nil) return;
     
-    CGSize size = [self.textLabel.text sizeWithAttributes:@{NSFontAttributeName:self.textLabel.font}];
+    CGSize size;
+    
+    if ([self.textLabel.text respondsToSelector:@selector(sizeWithAttributes:)]) {
+        size = [self.textLabel.text sizeWithAttributes:@{NSFontAttributeName:self.textLabel.font}];
+        size.width = ceilf(size.width);
+        size.height = ceilf(size.height);
+    } else {
+        size = [self.textLabel.text sizeWithFont:self.textLabel.font];
+    }
+    
     size.width += self.textSizePadding.width;
     size.height += self.textSizePadding.height;
     


### PR DESCRIPTION
- make it backwards compatible with iOS 6 after Pullrequest  (EddyBorja/MLPAccessoryBadge#2)
- iOS 7 and later: fixed fractional sizes in method 'sizeWithAttributes:'
