### PR TITLE
Add pragma to avoid unnecessary warning

### DIFF
--- a/MLPAccessoryBadge/MLPAccessoryBadge.m
+++ b/MLPAccessoryBadge/MLPAccessoryBadge.m
@@ -251,7 +251,9 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
         size.width = ceilf(size.width);
         size.height = ceilf(size.height);
     } else {
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         size = [self.textLabel.text sizeWithFont:self.textLabel.font];
+#pragma GCC diagnostic warning "-Wdeprecated-declarations"
     }
     
     size.width += self.textSizePadding.width;


### PR DESCRIPTION
The warning for sizeWithFont: is unnecessary because the conditional branching for sizeWithAttributes: and sizeWithFont: has been implemented.