### PR TITLE
Add explicit cast to ‘long’

### DIFF
--- a/MLPAccessoryBadge/MLPAccessoryBadge.m
+++ b/MLPAccessoryBadge/MLPAccessoryBadge.m
@@ -184,7 +184,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 - (void)setTextWithIntegerValue:(NSInteger)value
 {
-    [self setText:[NSString stringWithFormat:@"%i", value]];
+    [self setText:[NSString stringWithFormat:@"%li", (long)value]];
 }
 
 - (void)setText:(NSString *)string


### PR DESCRIPTION
Values of type ’NSInteger’ should not be used as format arguments.